### PR TITLE
docs: 更新文档以反映 AppSettingScanner 合并到 AppSettingManager

### DIFF
--- a/docs/architecture/app-setting-design.md
+++ b/docs/architecture/app-setting-design.md
@@ -59,7 +59,7 @@ src/one_dragon_qt/
 
 **文件**：`one_dragon/utils/plugin_module_loader.py`
 
-从 `ApplicationFactoryManager` 和 `AppSettingScanner` 中提取的共享逻辑：
+从 `ApplicationFactoryManager` 和 `AppSettingManager` 中提取的共享逻辑：
 
 | 函数 | 职责 |
 |------|------|
@@ -234,4 +234,4 @@ plugins/my_plugin/
     my_plugin_const.py              # 常量定义（已有模式）
 ```
 
-无需修改任何框架代码。扫描器会自动在 `THIRD_PARTY` 插件目录中发现并加载。
+无需修改任何框架代码。`AppSettingManager` 会自动在 `THIRD_PARTY` 插件目录中发现并加载。

--- a/src/one_dragon/utils/plugin_module_loader.py
+++ b/src/one_dragon/utils/plugin_module_loader.py
@@ -1,7 +1,7 @@
 """插件模块加载工具
 
 提供插件式文件发现和动态导入的共享工具函数。
-被 ApplicationFactoryManager 和 AppSettingScanner 共同使用。
+被 ApplicationFactoryManager 和 AppSettingManager 共同使用。
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## 修复文档与代码不一致的问题

在提交 `9618078` 中删除了 `app_setting_scanner.py`，将其扫描功能合并到 `AppSettingManager` 中，但文档仍保留部分对 `AppSettingScanner` 的引用。

### 修改内容

| 文件 | 位置 | 修改 |
|------|------|------|
| `one_dragon/utils/plugin_module_loader.py` | 文档字符串 | `AppSettingScanner` → `AppSettingManager` |
| `docs/app-setting-design.md` | 第 4.0 节 | `AppSettingScanner` → `AppSettingManager` |
| `docs/app-setting-design.md` | 第 7 节 | "扫描器" → `AppSettingManager` |