### PR TITLE
fix(plugins): 修复插件导入的安全与健壮性问题

### DIFF
--- a/src/one_dragon/base/operation/application/plugin_import_service.py
+++ b/src/one_dragon/base/operation/application/plugin_import_service.py
@@ -1,0 +1,494 @@
+"""插件导入服务
+
+处理第三方插件的导入、解压和验证。
+
+支持的导入方式：
+- ZIP 文件：自动解压到 plugins 目录
+- 目录：复制到 plugins 目录
+
+主要功能：
+- 验证插件结构（必须包含 *_factory.py）
+- 预览插件信息（从 *_const.py 读取）
+- 覆盖安装（可选）
+- 删除插件
+"""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from one_dragon.utils.log_utils import log
+
+if TYPE_CHECKING:
+    from one_dragon.base.operation.one_dragon_context import OneDragonContext
+
+
+@dataclass
+class ImportResult:
+    """导入操作结果
+
+    Attributes:
+        success: 是否成功
+        plugin_name: 插件名称
+        message: 结果消息
+        plugin_dir: 插件目录路径（如果插件已存在，返回已有目录路径）
+        new_version: 新版本号（用于覆盖安装时的版本比较）
+    """
+    success: bool
+    plugin_name: str
+    message: str
+    plugin_dir: Path | None = None
+    new_version: str | None = None
+
+
+@dataclass
+class PluginPreviewInfo:
+    """插件预览信息
+
+    用于导入前显示插件的基本信息。
+
+    Attributes:
+        plugin_name: 插件名称（目录名）
+        version: 版本号
+        author: 作者名称
+    """
+    plugin_name: str
+    version: str | None = None
+    author: str | None = None
+
+
+class PluginImportService:
+    """插件导入服务
+
+    处理第三方插件的导入、解压、验证和删除。
+    """
+
+    def __init__(self, ctx: OneDragonContext):
+        self.ctx = ctx
+
+    @property
+    def plugins_dir(self) -> Path:
+        """获取插件目录
+
+        返回项目根目录下的 plugins 目录。
+        """
+        import inspect
+        cls_file = inspect.getfile(self.ctx.__class__)
+        # 从 src 目录往上找项目根目录
+        parts = Path(cls_file).parts
+        try:
+            src_index = parts.index('src')
+            project_root = Path(*parts[:src_index])
+            return project_root / 'plugins'
+        except ValueError:
+            # 如果找不到 src 目录，使用旧逻辑作为后备
+            return Path(cls_file).parent.parent / 'plugins'
+
+    def import_plugins(self, zip_paths: list[str | Path], overwrite: bool = False) -> list[ImportResult]:
+        """导入多个插件
+
+        Args:
+            zip_paths: zip 文件路径列表
+            overwrite: 是否覆盖已存在的插件
+
+        Returns:
+            list[ImportResult]: 导入结果列表
+        """
+        results = []
+        for zip_path in zip_paths:
+            result = self.import_plugin(zip_path, overwrite=overwrite)
+            results.append(result)
+        return results
+
+    def import_plugin(self, zip_path: str | Path, overwrite: bool = False) -> ImportResult:
+        """导入单个插件
+
+        从 zip 文件解压插件到 plugins 目录。
+
+        Args:
+            zip_path: zip 文件路径
+            overwrite: 是否覆盖已存在的插件
+
+        Returns:
+            ImportResult: 导入结果
+        """
+        zip_path = Path(zip_path)
+
+        if not zip_path.exists():
+            return ImportResult(
+                success=False,
+                plugin_name=zip_path.stem,
+                message=f"文件不存在: {zip_path}"
+            )
+
+        if zip_path.suffix.lower() != '.zip':
+            return ImportResult(
+                success=False,
+                plugin_name=zip_path.stem,
+                message="只支持 .zip 格式的文件"
+            )
+
+        try:
+            with zipfile.ZipFile(zip_path, 'r') as zf:
+                # 验证 zip 文件结构
+                validation = self._validate_zip_structure(zf)
+                if not validation.success:
+                    return validation
+
+                # 获取插件目录名
+                plugin_dir_name = self._get_plugin_dir_name(zf)
+                if not plugin_dir_name:
+                    return ImportResult(
+                        success=False,
+                        plugin_name=zip_path.stem,
+                        message="无法确定插件目录名"
+                    )
+
+                target_dir = self.plugins_dir / plugin_dir_name
+
+                # 检查目录是否已存在
+                if target_dir.exists():
+                    if overwrite:
+                        # 覆盖安装：先删除旧目录
+                        shutil.rmtree(target_dir)
+                        log.info(f"覆盖安装: 已删除旧插件目录 {plugin_dir_name}")
+                    else:
+                        return ImportResult(
+                            success=False,
+                            plugin_name=plugin_dir_name,
+                            message=f"插件目录已存在: {plugin_dir_name}",
+                            plugin_dir=target_dir
+                        )
+
+                # 解压文件
+                self._extract_plugin(zf, target_dir, plugin_dir_name)
+
+                log.info(f"插件导入成功: {plugin_dir_name}")
+                return ImportResult(
+                    success=True,
+                    plugin_name=plugin_dir_name,
+                    message="导入成功",
+                    plugin_dir=target_dir
+                )
+
+        except zipfile.BadZipFile:
+            return ImportResult(
+                success=False,
+                plugin_name=zip_path.stem,
+                message="无效的 zip 文件"
+            )
+        except Exception as e:
+            log.error(f"导入插件失败: {e}", exc_info=True)
+            return ImportResult(
+                success=False,
+                plugin_name=zip_path.stem,
+                message=f"导入失败: {e}"
+            )
+
+    def _validate_zip_structure(self, zf: zipfile.ZipFile) -> ImportResult:
+        """验证 zip 文件结构
+
+        检查 zip 文件是否包含有效的插件结构（至少一个 *_factory.py 文件）。
+
+        Args:
+            zf: ZipFile 对象
+
+        Returns:
+            ImportResult: 验证结果
+        """
+        file_list = zf.namelist()
+
+        # 检查是否有 factory 文件
+        has_factory = any(name.endswith('_factory.py') for name in file_list)
+        if not has_factory:
+            return ImportResult(
+                success=False,
+                plugin_name="",
+                message="无效的插件结构：缺少 *_factory.py 文件"
+            )
+
+        return ImportResult(success=True, plugin_name="", message="")
+
+    def preview_plugin(self, zip_path: str | Path) -> PluginPreviewInfo | None:
+        """预览 zip 中的插件信息（不解压）
+
+        Args:
+            zip_path: zip 文件路径
+
+        Returns:
+            PluginPreviewInfo | None: 插件预览信息
+        """
+        zip_path = Path(zip_path)
+        if not zip_path.exists() or zip_path.suffix.lower() != '.zip':
+            return None
+
+        try:
+            with zipfile.ZipFile(zip_path, 'r') as zf:
+                plugin_dir_name = self._get_plugin_dir_name(zf)
+                if not plugin_dir_name:
+                    return None
+
+                # 查找 const 文件并读取版本信息
+                version = None
+                author = None
+                for name in zf.namelist():
+                    if name.endswith('_const.py'):
+                        try:
+                            content = zf.read(name).decode('utf-8')
+                            version = self._extract_const_value(content, 'PLUGIN_VERSION')
+                            author = self._extract_const_value(content, 'PLUGIN_AUTHOR')
+                            break
+                        except Exception:
+                            pass
+
+                return PluginPreviewInfo(
+                    plugin_name=plugin_dir_name,
+                    version=version,
+                    author=author
+                )
+        except Exception:
+            return None
+
+    def _extract_const_value(self, content: str, const_name: str) -> str | None:
+        """从代码内容中提取常量值
+
+        Args:
+            content: 代码内容
+            const_name: 常量名
+
+        Returns:
+            str | None: 常量值
+        """
+        import re
+        # 匹配 CONST_NAME = 'value' 或 CONST_NAME = "value"
+        pattern = rf"{const_name}\s*=\s*['\"](.+?)['\"]"
+        match = re.search(pattern, content)
+        return match.group(1) if match else None
+
+    def _get_plugin_dir_name(self, zf: zipfile.ZipFile) -> str | None:
+        """从 zip 文件获取插件目录名
+
+        Args:
+            zf: ZipFile 对象
+
+        Returns:
+            str | None: 插件目录名
+        """
+        file_list = zf.namelist()
+
+        # 查找第一个 factory 文件，确定插件目录
+        for name in file_list:
+            if name.endswith('_factory.py'):
+                parts = name.split('/')
+                if len(parts) >= 2:
+                    # 如果 factory 文件在子目录中，使用父目录名
+                    return parts[0]
+                # 如果 factory 直接在根目录，使用文件名（去掉 _factory.py）
+                return name.replace('_factory.py', '')
+
+        return None
+
+    def _extract_plugin(
+        self,
+        zf: zipfile.ZipFile,
+        target_dir: Path,
+        plugin_dir_name: str
+    ) -> None:
+        """解压插件到目标目录
+
+        Args:
+            zf: ZipFile 对象
+            target_dir: 目标目录
+            plugin_dir_name: 插件目录名
+        """
+        # 确保 plugins 目录存在
+        self.plugins_dir.mkdir(parents=True, exist_ok=True)
+
+        file_list = zf.namelist()
+
+        # 检查 zip 文件结构
+        # 情况1: 所有文件都在一个同名子目录下（例如 my_plugin/xxx.py）
+        # 情况2: 文件直接在根目录（例如 xxx_factory.py）
+        has_root_dir = all(
+            name.startswith(plugin_dir_name + '/') or name == plugin_dir_name + '/'
+            for name in file_list if name
+        )
+
+        if has_root_dir:
+            # 直接解压，zip 内部已经有目录结构
+            zf.extractall(self.plugins_dir)
+        else:
+            # 需要创建目录并解压到其中
+            target_dir.mkdir(parents=True, exist_ok=True)
+            for member in file_list:
+                if member.endswith('/'):
+                    # 创建目录
+                    (target_dir / member).mkdir(parents=True, exist_ok=True)
+                else:
+                    # 解压文件
+                    source = zf.read(member)
+                    dest_path = target_dir / member
+                    dest_path.parent.mkdir(parents=True, exist_ok=True)
+                    dest_path.write_bytes(source)
+
+    def import_directory(self, dir_path: str | Path, overwrite: bool = False) -> ImportResult:
+        """导入目录格式的插件
+
+        将插件目录复制到 plugins 目录。
+
+        Args:
+            dir_path: 插件目录路径
+            overwrite: 是否覆盖已存在的插件
+
+        Returns:
+            ImportResult: 导入结果
+        """
+        dir_path = Path(dir_path)
+
+        if not dir_path.exists():
+            return ImportResult(
+                success=False,
+                plugin_name=dir_path.name,
+                message=f"目录不存在: {dir_path}"
+            )
+
+        if not dir_path.is_dir():
+            return ImportResult(
+                success=False,
+                plugin_name=dir_path.name,
+                message="路径不是目录"
+            )
+
+        # 验证目录结构
+        has_factory = any(dir_path.glob('*_factory.py'))
+        if not has_factory:
+            return ImportResult(
+                success=False,
+                plugin_name=dir_path.name,
+                message="无效的插件结构：缺少 *_factory.py 文件"
+            )
+
+        plugin_name = dir_path.name
+        target_dir = self.plugins_dir / plugin_name
+
+        # 检查目录是否已存在
+        if target_dir.exists():
+            if overwrite:
+                shutil.rmtree(target_dir)
+                log.info(f"覆盖安装: 已删除旧插件目录 {plugin_name}")
+            else:
+                return ImportResult(
+                    success=False,
+                    plugin_name=plugin_name,
+                    message=f"插件目录已存在: {plugin_name}",
+                    plugin_dir=target_dir
+                )
+
+        try:
+            # 确保 plugins 目录存在
+            self.plugins_dir.mkdir(parents=True, exist_ok=True)
+
+            # 复制目录
+            shutil.copytree(dir_path, target_dir)
+            log.info(f"目录插件导入成功: {plugin_name}")
+            return ImportResult(
+                success=True,
+                plugin_name=plugin_name,
+                message="导入成功",
+                plugin_dir=target_dir
+            )
+        except Exception as e:
+            log.error(f"导入目录插件失败: {e}", exc_info=True)
+            return ImportResult(
+                success=False,
+                plugin_name=plugin_name,
+                message=f"导入失败: {e}"
+            )
+
+    def preview_directory(self, dir_path: str | Path) -> PluginPreviewInfo | None:
+        """预览目录中的插件信息
+
+        Args:
+            dir_path: 插件目录路径
+
+        Returns:
+            PluginPreviewInfo | None: 插件预览信息
+        """
+        dir_path = Path(dir_path)
+        if not dir_path.exists() or not dir_path.is_dir():
+            return None
+
+        # 检查是否有 factory 文件
+        has_factory = any(dir_path.glob('*_factory.py'))
+        if not has_factory:
+            return None
+
+        # 查找 const 文件并读取信息
+        version = None
+        author = None
+        for const_file in dir_path.glob('*_const.py'):
+            try:
+                content = const_file.read_text(encoding='utf-8')
+                version = self._extract_const_value(content, 'PLUGIN_VERSION')
+                author = self._extract_const_value(content, 'PLUGIN_AUTHOR')
+                break
+            except Exception:
+                pass
+
+        return PluginPreviewInfo(
+            plugin_name=dir_path.name,
+            version=version,
+            author=author
+        )
+
+    def delete_plugin(self, plugin_dir: str | Path) -> ImportResult:
+        """删除插件
+
+        Args:
+            plugin_dir: 插件目录路径或名称
+
+        Returns:
+            ImportResult: 删除结果
+        """
+        if isinstance(plugin_dir, str):
+            # 如果只是目录名，构建完整路径
+            if not Path(plugin_dir).is_absolute():
+                plugin_dir = self.plugins_dir / plugin_dir
+
+        plugin_dir = Path(plugin_dir)
+        plugin_name = plugin_dir.name
+
+        if not plugin_dir.exists():
+            return ImportResult(
+                success=False,
+                plugin_name=plugin_name,
+                message=f"插件目录不存在: {plugin_name}"
+            )
+
+        # 安全检查：确保删除的是 plugins 目录下的内容
+        if self.plugins_dir not in plugin_dir.parents and plugin_dir != self.plugins_dir:
+            return ImportResult(
+                success=False,
+                plugin_name=plugin_name,
+                message="只能删除 plugins 目录下的插件"
+            )
+
+        try:
+            shutil.rmtree(plugin_dir)
+            log.info(f"插件已删除: {plugin_name}")
+            return ImportResult(
+                success=True,
+                plugin_name=plugin_name,
+                message="删除成功"
+            )
+        except Exception as e:
+            log.error(f"删除插件失败: {e}", exc_info=True)
+            return ImportResult(
+                success=False,
+                plugin_name=plugin_name,
+                message=f"删除失败: {e}"
+            )

--- a/src/one_dragon/base/operation/application/plugin_import_service.py
+++ b/src/one_dragon/base/operation/application/plugin_import_service.py
@@ -67,8 +67,8 @@ class PluginImportService:
     处理第三方插件的导入、解压、验证和删除。
     """
 
-    def __init__(self, ctx: OneDragonContext):
-        self.ctx = ctx
+    def __init__(self, ctx: OneDragonContext) -> None:
+        self.ctx: OneDragonContext = ctx
 
     @property
     def plugins_dir(self) -> Path:
@@ -108,6 +108,7 @@ class PluginImportService:
         """导入单个插件
 
         从 zip 文件解压插件到 plugins 目录。
+        覆盖安装时先解压到临时目录，成功后原子替换旧目录。
 
         Args:
             zip_path: zip 文件路径
@@ -139,7 +140,7 @@ class PluginImportService:
                 if not validation.success:
                     return validation
 
-                # 获取插件目录名
+                # 获取插件目录名（已经过安全净化）
                 plugin_dir_name = self._get_plugin_dir_name(zf)
                 if not plugin_dir_name:
                     return ImportResult(
@@ -150,12 +151,23 @@ class PluginImportService:
 
                 target_dir = self.plugins_dir / plugin_dir_name
 
+                # 安全检查：确保 target_dir 在 plugins 目录下
+                plugins_dir_resolved = self.plugins_dir.resolve(strict=False)
+                target_dir_resolved = target_dir.resolve(strict=False)
+                if not target_dir_resolved.is_relative_to(plugins_dir_resolved):
+                    return ImportResult(
+                        success=False,
+                        plugin_name=plugin_dir_name,
+                        message=f"非法的插件目录: {plugin_dir_name}"
+                    )
+
                 # 检查目录是否已存在
                 if target_dir.exists():
                     if overwrite:
-                        # 覆盖安装：先删除旧目录
-                        shutil.rmtree(target_dir)
-                        log.info(f"覆盖安装: 已删除旧插件目录 {plugin_dir_name}")
+                        # 先解压到临时目录，成功后原子替换
+                        return self._atomic_extract_plugin(
+                            zf, target_dir, plugin_dir_name
+                        )
                     else:
                         return ImportResult(
                             success=False,
@@ -164,7 +176,7 @@ class PluginImportService:
                             plugin_dir=target_dir
                         )
 
-                # 解压文件
+                # 新安装：直接解压
                 self._extract_plugin(zf, target_dir, plugin_dir_name)
 
                 log.info(f"插件导入成功: {plugin_dir_name}")
@@ -272,11 +284,13 @@ class PluginImportService:
     def _get_plugin_dir_name(self, zf: zipfile.ZipFile) -> str | None:
         """从 zip 文件获取插件目录名
 
+        安全净化返回的目录名，拒绝路径穿越（如 .. 或绝对路径）。
+
         Args:
             zf: ZipFile 对象
 
         Returns:
-            str | None: 插件目录名
+            str | None: 安全的插件目录名
         """
         file_list = zf.namelist()
 
@@ -285,12 +299,44 @@ class PluginImportService:
             if name.endswith('_factory.py'):
                 parts = name.split('/')
                 if len(parts) >= 2:
-                    # 如果 factory 文件在子目录中，使用父目录名
-                    return parts[0]
-                # 如果 factory 直接在根目录，使用文件名（去掉 _factory.py）
-                return name.replace('_factory.py', '')
+                    # 如果 factory 文件在子目录中，使用顶层目录名
+                    candidate = parts[0]
+                else:
+                    # 如果 factory 直接在根目录，使用文件名（去掉 _factory.py）
+                    candidate = name.replace('_factory.py', '')
+
+                # 安全检查：净化候选目录名
+                return self._sanitize_dir_name(candidate)
 
         return None
+
+    def _sanitize_dir_name(self, name: str) -> str | None:
+        """净化目录名，拒绝路径穿越
+
+        拒绝包含 .. 、空字符串和以 / 开头的绝对路径。
+        只接受安全简单的目录名。
+
+        Args:
+            name: 候选目录名
+
+        Returns:
+            str | None: 安全的目录名，如果非法则返回 None
+        """
+        # 去除首尾空白
+        name = name.strip()
+        if not name:
+            return None
+
+        # 拒绝路径穿越和绝对路径
+        if name.startswith('/') or name.startswith('\\'):
+            return None
+        if '..' in name:
+            return None
+        # 拒绝包含路径分隔符的多级路径（如 a/b/c）
+        if '/' in name or '\\' in name:
+            return None
+
+        return name
 
     def _extract_plugin(
         self,
@@ -300,9 +346,11 @@ class PluginImportService:
     ) -> None:
         """解压插件到目标目录
 
+        对每个 ZIP 条目做路径安全检查，防止路径穿越。
+
         Args:
             zf: ZipFile 对象
-            target_dir: 目标目录
+            target_dir: 目标目录（必须在 plugins_dir 下）
             plugin_dir_name: 插件目录名
         """
         # 确保 plugins 目录存在
@@ -319,21 +367,148 @@ class PluginImportService:
         )
 
         if has_root_dir:
-            # 直接解压，zip 内部已经有目录结构
-            zf.extractall(self.plugins_dir)
+            # ZIP 内部有顶层目录结构，直接提取到 plugins 目录
+            # 逐文件安全提取（避免 extractall 的路径穿越风险）
+            for member in file_list:
+                # 跳过目录条目
+                if member.endswith('/'):
+                    continue
+                self._safe_extract_member(zf, member, self.plugins_dir)
         else:
-            # 需要创建目录并解压到其中
+            # 文件直接在 ZIP 根目录，需要创建插件目录并解压到其中
             target_dir.mkdir(parents=True, exist_ok=True)
             for member in file_list:
                 if member.endswith('/'):
                     # 创建目录
-                    (target_dir / member).mkdir(parents=True, exist_ok=True)
+                    safe_subdir = self._sanitize_member_path(member)
+                    if safe_subdir is not None:
+                        (target_dir / safe_subdir).mkdir(parents=True, exist_ok=True)
                 else:
-                    # 解压文件
-                    source = zf.read(member)
-                    dest_path = target_dir / member
-                    dest_path.parent.mkdir(parents=True, exist_ok=True)
-                    dest_path.write_bytes(source)
+                    self._safe_extract_member(zf, member, target_dir)
+
+    def _safe_extract_member(
+        self,
+        zf: zipfile.ZipFile,
+        member: str,
+        base_dir: Path
+    ) -> None:
+        """安全地提取单个 ZIP 条目
+
+        验证目标路径在 base_dir 内，防止路径穿越。
+
+        Args:
+            zf: ZipFile 对象
+            member: ZIP 条目名
+            base_dir: 基准目录
+        """
+        # 净化和验证路径
+        safe_path = self._sanitize_member_path(member)
+        if safe_path is None:
+            log.warning(f"跳过非法路径: {member}")
+            return
+
+        dest_path = base_dir / safe_path
+
+        # 双重检查：确保解析后的路径在 plugins 目录下
+        plugins_dir_resolved = self.plugins_dir.resolve(strict=False)
+        dest_resolved = dest_path.resolve(strict=False)
+        if not dest_resolved.is_relative_to(plugins_dir_resolved):
+            log.warning(f"跳过 plugins 目录外的路径: {member}")
+            return
+
+        # 写入文件
+        source = zf.read(member)
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_bytes(source)
+
+    def _sanitize_member_path(self, member: str) -> str | None:
+        """净化 ZIP 条目路径
+
+        去除开头的 plugin_dir_name/ 前缀（has_root_dir 模式下），
+        并拒绝包含 .. 或绝对路径的条目。
+
+        Args:
+            member: ZIP 条目名
+
+        Returns:
+            str | None: 安全的相对路径，如果非法则返回 None
+        """
+        # 去除末尾斜杠（目录条目）
+        member = member.rstrip('/')
+
+        # 按 / 拆分段
+        segments = member.split('/')
+
+        # 净化每个段
+        safe_segments = []
+        for seg in segments:
+            if seg == '' or seg == '..':
+                # 拒绝空段和路径穿越
+                return None
+            if '\\' in seg:
+                # 拒绝反斜杠（Windows 路径穿越）
+                return None
+            safe_segments.append(seg)
+
+        if not safe_segments:
+            return None
+
+        return '/'.join(safe_segments)
+
+    def _atomic_extract_plugin(
+        self,
+        zf: zipfile.ZipFile,
+        target_dir: Path,
+        plugin_dir_name: str
+    ) -> ImportResult:
+        """原子覆盖安装：先解压到临时目录，成功后替换旧目录
+
+        避免覆盖安装时先删旧目录再解压导致旧版本数据丢失的问题。
+
+        Args:
+            zf: ZipFile 对象
+            target_dir: 最终目标目录
+            plugin_dir_name: 插件目录名
+
+        Returns:
+            ImportResult: 导入结果
+        """
+        tmp_dir = target_dir.with_name(plugin_dir_name + '.tmp')
+
+        # 清理可能残留的临时目录
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
+
+        try:
+            # 先解压到临时目录
+            self._extract_plugin(zf, tmp_dir, plugin_dir_name)
+
+            # 验证临时目录内容有效（包含 factory 文件）
+            if not any(tmp_dir.glob('*_factory.py')):
+                shutil.rmtree(tmp_dir)
+                return ImportResult(
+                    success=False,
+                    plugin_name=plugin_dir_name,
+                    message="覆盖安装失败：临时目录缺少 *_factory.py 文件"
+                )
+
+            # 解压成功，交换目录
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            tmp_dir.rename(target_dir)
+
+            log.info(f"覆盖安装成功: {plugin_dir_name}")
+            return ImportResult(
+                success=True,
+                plugin_name=plugin_dir_name,
+                message="覆盖安装成功",
+                plugin_dir=target_dir
+            )
+        except Exception:
+            # 失败时清理临时目录
+            if tmp_dir.exists():
+                shutil.rmtree(tmp_dir)
+            raise
 
     def import_directory(self, dir_path: str | Path, overwrite: bool = False) -> ImportResult:
         """导入目录格式的插件
@@ -375,11 +550,23 @@ class PluginImportService:
         plugin_name = dir_path.name
         target_dir = self.plugins_dir / plugin_name
 
+        # 安全检查：确保 target_dir 在 plugins 目录下
+        plugins_dir_resolved = self.plugins_dir.resolve(strict=False)
+        target_dir_resolved = target_dir.resolve(strict=False)
+        if not target_dir_resolved.is_relative_to(plugins_dir_resolved):
+            return ImportResult(
+                success=False,
+                plugin_name=plugin_name,
+                message=f"非法的插件目录: {plugin_name}"
+            )
+
         # 检查目录是否已存在
         if target_dir.exists():
             if overwrite:
-                shutil.rmtree(target_dir)
-                log.info(f"覆盖安装: 已删除旧插件目录 {plugin_name}")
+                # 原子覆盖：先复制到临时目录，成功后替换
+                return self._atomic_copy_plugin(
+                    dir_path, target_dir, plugin_name
+                )
             else:
                 return ImportResult(
                     success=False,
@@ -408,6 +595,61 @@ class PluginImportService:
                 plugin_name=plugin_name,
                 message=f"导入失败: {e}"
             )
+
+    def _atomic_copy_plugin(
+        self,
+        src_dir: Path,
+        target_dir: Path,
+        plugin_name: str
+    ) -> ImportResult:
+        """原子覆盖复制：先复制到临时目录，成功后替换旧目录
+
+        避免覆盖安装时先删旧目录再复制导致旧版本数据丢失的问题。
+
+        Args:
+            src_dir: 源目录路径
+            target_dir: 最终目标目录
+            plugin_name: 插件名称
+
+        Returns:
+            ImportResult: 导入结果
+        """
+        tmp_dir = target_dir.with_name(plugin_name + '.tmp')
+
+        # 清理可能残留的临时目录
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
+
+        try:
+            # 先复制到临时目录
+            shutil.copytree(src_dir, tmp_dir)
+
+            # 验证临时目录内容有效（包含 factory 文件）
+            if not any(tmp_dir.glob('*_factory.py')):
+                shutil.rmtree(tmp_dir)
+                return ImportResult(
+                    success=False,
+                    plugin_name=plugin_name,
+                    message="覆盖安装失败：临时目录缺少 *_factory.py 文件"
+                )
+
+            # 复制成功，交换目录
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            tmp_dir.rename(target_dir)
+
+            log.info(f"覆盖安装成功: {plugin_name}")
+            return ImportResult(
+                success=True,
+                plugin_name=plugin_name,
+                message="覆盖安装成功",
+                plugin_dir=target_dir
+            )
+        except Exception:
+            # 失败时清理临时目录
+            if tmp_dir.exists():
+                shutil.rmtree(tmp_dir)
+            raise
 
     def preview_directory(self, dir_path: str | Path) -> PluginPreviewInfo | None:
         """预览目录中的插件信息
@@ -460,17 +702,30 @@ class PluginImportService:
                 plugin_dir = self.plugins_dir / plugin_dir
 
         plugin_dir = Path(plugin_dir)
-        plugin_name = plugin_dir.name
 
-        if not plugin_dir.exists():
+        # 先 resolve 再做安全检查，防止 ../ 绕过
+        plugin_dir_resolved = plugin_dir.resolve(strict=False)
+        plugins_dir_resolved = self.plugins_dir.resolve(strict=False)
+
+        plugin_name = plugin_dir_resolved.name
+
+        if not plugin_dir_resolved.exists():
             return ImportResult(
                 success=False,
                 plugin_name=plugin_name,
                 message=f"插件目录不存在: {plugin_name}"
             )
 
-        # 安全检查：确保删除的是 plugins 目录下的内容
-        if self.plugins_dir not in plugin_dir.parents and plugin_dir != self.plugins_dir:
+        # 安全检查：禁止删除 plugins 根目录本身
+        if plugin_dir_resolved == plugins_dir_resolved:
+            return ImportResult(
+                success=False,
+                plugin_name=plugin_name,
+                message="不能删除 plugins 根目录"
+            )
+
+        # 安全检查：确保要删除的目录在 plugins 目录内
+        if not plugin_dir_resolved.is_relative_to(plugins_dir_resolved):
             return ImportResult(
                 success=False,
                 plugin_name=plugin_name,
@@ -478,7 +733,7 @@ class PluginImportService:
             )
 
         try:
-            shutil.rmtree(plugin_dir)
+            shutil.rmtree(plugin_dir_resolved)
             log.info(f"插件已删除: {plugin_name}")
             return ImportResult(
                 success=True,

--- a/src/zzz_od/gui/view/setting/app_setting_interface.py
+++ b/src/zzz_od/gui/view/setting/app_setting_interface.py
@@ -7,8 +7,10 @@ from one_dragon_qt.widgets.pivot_navi_interface import PivotNavigatorInterface
 from zzz_od.context.zzz_context import ZContext
 from zzz_od.gui.view.setting.setting_game_interface import SettingGameInterface
 from zzz_od.gui.view.setting.setting_overlay_interface import SettingOverlayInterface
-
-from zzz_od.gui.view.setting.zzz_resource_download_interface import ZResourceDownloadInterface
+from zzz_od.gui.view.setting.setting_plugin_interface import SettingPluginInterface
+from zzz_od.gui.view.setting.zzz_resource_download_interface import (
+    ZResourceDownloadInterface,
+)
 
 
 class AppSettingInterface(PivotNavigatorInterface):
@@ -26,6 +28,7 @@ class AppSettingInterface(PivotNavigatorInterface):
         self.add_sub_interface(SettingGameInterface(ctx=self.ctx))
         self.add_sub_interface(SettingOverlayInterface(ctx=self.ctx))
         self.add_sub_interface(ZResourceDownloadInterface(ctx=self.ctx))
+        self.add_sub_interface(SettingPluginInterface(ctx=self.ctx))
 
         self.add_sub_interface(SettingEnvInterface(ctx=self.ctx))
         self.add_sub_interface(SettingPushInterface(ctx=self.ctx))

--- a/src/zzz_od/gui/view/setting/setting_plugin_interface.py
+++ b/src/zzz_od/gui/view/setting/setting_plugin_interface.py
@@ -1,0 +1,642 @@
+import contextlib
+import os
+import subprocess
+import sys
+import webbrowser
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QFileDialog, QWidget
+from qfluentwidgets import (
+    FluentIcon,
+    InfoBar,
+    InfoBarPosition,
+    MessageBox,
+    PrimaryPushButton,
+    PushButton,
+    SettingCardGroup,
+    ToolButton,
+)
+
+from one_dragon.base.operation.application.plugin_import_service import (
+    PluginImportService,
+)
+from one_dragon.base.operation.application.plugin_info import PluginInfo
+from one_dragon.utils.i18_utils import gt
+from one_dragon.utils.log_utils import log
+from one_dragon_qt.widgets.column import Column
+from one_dragon_qt.widgets.setting_card.help_card import HelpCard
+from one_dragon_qt.widgets.setting_card.multi_push_setting_card import (
+    MultiPushSettingCard,
+)
+from one_dragon_qt.widgets.vertical_scroll_interface import VerticalScrollInterface
+from zzz_od.context.zzz_context import ZContext
+
+
+class PluginCard(MultiPushSettingCard):
+    """单个插件的卡片"""
+
+    def __init__(
+        self,
+        plugin_info: PluginInfo,
+        on_delete: callable,
+        on_open_homepage: callable,
+        parent=None
+    ):
+        self.plugin_info = plugin_info
+        self.on_delete_callback = on_delete
+        self.on_open_homepage_callback = on_open_homepage
+
+        # 创建按钮
+        buttons = []
+
+        # 主页按钮（如果有链接）
+        if plugin_info.homepage:
+            self.homepage_btn = PushButton(text=gt("主页"))
+            self.homepage_btn.clicked.connect(self._on_homepage_clicked)
+            buttons.append(self.homepage_btn)
+
+        # 删除按钮
+        self.delete_btn = ToolButton(FluentIcon.DELETE, parent=None)
+        self.delete_btn.clicked.connect(self._on_delete_clicked)
+        buttons.append(self.delete_btn)
+
+        # 构建描述文本
+        content_parts = []
+        if plugin_info.version:
+            content_parts.append(f"v{plugin_info.version}")
+        if plugin_info.author:
+            content_parts.append(f"作者: {plugin_info.author}")
+        if plugin_info.description:
+            content_parts.append(plugin_info.description)
+
+        content = " | ".join(content_parts) if content_parts else ""
+
+        MultiPushSettingCard.__init__(
+            self,
+            btn_list=buttons,
+            title=plugin_info.app_name,
+            content=content,
+            icon=FluentIcon.LIBRARY,
+        )
+
+    def _on_homepage_clicked(self) -> None:
+        if self.on_open_homepage_callback:
+            self.on_open_homepage_callback(self.plugin_info)
+
+    def _on_delete_clicked(self) -> None:
+        if self.on_delete_callback:
+            self.on_delete_callback(self.plugin_info)
+
+    def update_plugin_info(self, plugin_info: PluginInfo) -> None:
+        """更新插件信息
+
+        Args:
+            plugin_info: 新的插件信息
+        """
+        self.plugin_info = plugin_info
+
+        # 更新标题
+        self.titleLabel.setText(plugin_info.app_name)
+
+        # 更新描述
+        content_parts = []
+        if plugin_info.version:
+            content_parts.append(f"v{plugin_info.version}")
+        if plugin_info.author:
+            content_parts.append(f"作者: {plugin_info.author}")
+        if plugin_info.description:
+            content_parts.append(plugin_info.description)
+
+        content = " | ".join(content_parts) if content_parts else ""
+        self.contentLabel.setText(content)
+
+        # 更新主页按钮可见性
+        if hasattr(self, 'homepage_btn'):
+            self.homepage_btn.setVisible(bool(plugin_info.homepage))
+
+
+class SettingPluginInterface(VerticalScrollInterface):
+    """插件管理界面"""
+
+    def __init__(self, ctx: ZContext, parent=None):
+        self.ctx: ZContext = ctx
+        self.plugin_import_service = PluginImportService(ctx)
+        self._plugin_cards: list[PluginCard] = []
+        self._empty_card: MultiPushSettingCard | None = None
+
+        VerticalScrollInterface.__init__(
+            self,
+            object_name='setting_plugin_interface',
+            content_widget=None,
+            parent=parent,
+            nav_text_cn='插件管理'
+        )
+
+    def get_content_widget(self) -> QWidget:
+        content_widget = Column(self)
+
+        content_widget.add_widget(self._init_action_group())
+        content_widget.add_widget(self._init_plugin_list_group())
+
+        return content_widget
+
+    def _init_action_group(self) -> SettingCardGroup:
+        """初始化操作按钮组"""
+        action_group = SettingCardGroup(gt('操作'))
+
+        # 导入 ZIP 按钮
+        self.import_btn = PrimaryPushButton(FluentIcon.ADD, gt('导入 ZIP'))
+        self.import_btn.clicked.connect(self._on_import_clicked)
+
+        # 导入目录按钮
+        self.import_dir_btn = PushButton(FluentIcon.FOLDER_ADD, gt('导入目录'))
+        self.import_dir_btn.clicked.connect(self._on_import_dir_clicked)
+
+        # 刷新按钮
+        self.refresh_btn = PushButton(FluentIcon.SYNC, gt('刷新'))
+        self.refresh_btn.clicked.connect(self._on_refresh_clicked)
+
+        # 打开目录按钮
+        self.open_dir_btn = PushButton(FluentIcon.FOLDER, gt('打开目录'))
+        self.open_dir_btn.clicked.connect(self._on_open_dir_clicked)
+
+        # 创建操作卡片
+        action_card = MultiPushSettingCard(
+            btn_list=[self.import_btn, self.import_dir_btn, self.refresh_btn, self.open_dir_btn],
+            title=gt('插件操作'),
+            content=gt('导入 zip 格式或目录格式的插件'),
+            icon=FluentIcon.APPLICATION,
+        )
+        action_group.addSettingCard(action_card)
+
+        # 说明卡片
+        self.help_card = HelpCard(
+            url='',
+            title='插件开发说明',
+            content='第三方插件需要包含 *_const.py 和 *_factory.py 文件，详见 plugins 目录下的 README.md'
+        )
+        action_group.addSettingCard(self.help_card)
+
+        return action_group
+
+    def _init_plugin_list_group(self) -> SettingCardGroup:
+        """初始化插件列表组"""
+        self.plugin_list_group = SettingCardGroup(gt('已安装插件'))
+
+        # 创建空状态卡片（始终存在，仅通过显示/隐藏控制）
+        self._empty_card = MultiPushSettingCard(
+            btn_list=[],
+            title=gt('暂无第三方插件'),
+            content=gt('点击"导入插件"按钮添加新插件'),
+            icon=FluentIcon.INFO,
+        )
+        self.plugin_list_group.addSettingCard(self._empty_card)
+
+        return self.plugin_list_group
+
+    def on_interface_shown(self) -> None:
+        VerticalScrollInterface.on_interface_shown(self)
+        self._refresh_plugin_list()
+
+    def _clear_plugin_cards(self) -> None:
+        """清除旧的插件卡片（不删除 empty_card）
+
+        注意：此方法只隐藏卡片，不真正删除。
+        真正的删除在 _update_plugin_cards 中通过复用逻辑处理。
+        """
+        for card in self._plugin_cards:
+            with contextlib.suppress(RuntimeError):
+                card.hide()
+
+    def _refresh_plugin_list(self) -> None:
+        """刷新插件列表显示
+
+        使用复用逻辑：
+        - 如果插件数量增加，创建新卡片
+        - 如果插件数量减少，隐藏多余卡片
+        - 更新现有卡片的内容
+        """
+        # 获取第三方插件
+        third_party_plugins = self.ctx.factory_manager.third_party_plugins
+
+        if not third_party_plugins:
+            # 隐藏所有插件卡片，显示空状态
+            for card in self._plugin_cards:
+                with contextlib.suppress(RuntimeError):
+                    card.hide()
+            self._empty_card.show()
+            self.plugin_list_group.adjustSize()
+            return
+
+        # 隐藏空状态
+        self._empty_card.hide()
+
+        # 更新卡片数量
+        current_count = len(self._plugin_cards)
+        new_count = len(third_party_plugins)
+
+        if new_count > current_count:
+            # 需要添加新卡片
+            for i in range(current_count, new_count):
+                card = PluginCard(
+                    plugin_info=third_party_plugins[i],
+                    on_delete=self._on_delete_plugin,
+                    on_open_homepage=self._on_open_homepage,
+                    parent=self
+                )
+                self._plugin_cards.append(card)
+                self.plugin_list_group.addSettingCard(card)
+        elif new_count < current_count:
+            # 隐藏多余卡片
+            for i in range(new_count, current_count):
+                with contextlib.suppress(RuntimeError):
+                    self._plugin_cards[i].hide()
+
+        # 更新所有可见卡片的内容
+        for i, plugin_info in enumerate(third_party_plugins):
+            card = self._plugin_cards[i]
+            card.update_plugin_info(plugin_info)
+            card.show()
+
+        # 调整组大小
+        self.plugin_list_group.adjustSize()
+
+    def _on_import_clicked(self) -> None:
+        """导入按钮点击"""
+        file_paths, _ = QFileDialog.getOpenFileNames(
+            self,
+            gt('选择插件压缩包'),
+            '',
+            'ZIP Files (*.zip)'
+        )
+
+        if not file_paths:
+            return
+
+        # 预览所有插件信息
+        previews = []
+        for fp in file_paths:
+            preview = self.plugin_import_service.preview_plugin(fp)
+            if preview:
+                previews.append((fp, preview))
+            else:
+                previews.append((fp, None))
+
+        # 构建预览信息
+        preview_lines = []
+        for fp, preview in previews:
+            if preview:
+                line = f"• {preview.plugin_name}"
+                if preview.version:
+                    line += f" (v{preview.version})"
+                if preview.author:
+                    line += f" - {preview.author}"
+                preview_lines.append(line)
+            else:
+                from pathlib import Path
+                preview_lines.append(f"• {Path(fp).stem} (无法读取信息)")
+
+        # 显示预览确认对话框
+        msg = MessageBox(
+            title=gt('确认导入'),
+            content=gt(f'即将导入以下插件：\n\n{chr(10).join(preview_lines)}'),
+            parent=self
+        )
+        msg.yesButton.setText(gt('确认导入'))
+        msg.cancelButton.setText(gt('取消'))
+
+        if not msg.exec():
+            return
+
+        # 执行导入（不覆盖）
+        results = self.plugin_import_service.import_plugins(file_paths, overwrite=False)
+
+        # 找出因已存在而失败的插件
+        existing_plugins = [
+            (file_paths[i], r) for i, r in enumerate(results)
+            if not r.success and r.plugin_dir is not None
+        ]
+
+        # 如果有已存在的插件，询问是否覆盖
+        if existing_plugins:
+            # 获取已安装插件的版本信息
+            installed_plugins = {
+                p.app_id: p for p in self.ctx.factory_manager.third_party_plugins
+            }
+
+            # 检查版本信息
+            overwrite_info = []  # (file_path, plugin_name, new_ver, old_ver, is_downgrade)
+            for fp, r in existing_plugins:
+                preview = self.plugin_import_service.preview_plugin(fp)
+                new_ver = preview.version if preview else None
+                old_ver = installed_plugins.get(r.plugin_name, None)
+                old_ver_str = old_ver.version if old_ver else None
+
+                is_downgrade = self._is_version_lower(new_ver, old_ver_str)
+                overwrite_info.append((fp, r.plugin_name, new_ver, old_ver_str, is_downgrade))
+
+            # 区分正常覆盖和降级覆盖
+            normal_overwrite = [(fp, name) for fp, name, _, _, is_down in overwrite_info if not is_down]
+            downgrade_overwrite = [(fp, name, new_v, old_v) for fp, name, new_v, old_v, is_down in overwrite_info if is_down]
+
+            overwrite_paths = []
+
+            # 处理正常覆盖
+            if normal_overwrite:
+                names = [name for _, name in normal_overwrite]
+                msg = MessageBox(
+                    title=gt('插件已存在'),
+                    content=gt(f'以下插件已存在，是否覆盖安装？\n\n{chr(10).join(names)}'),
+                    parent=self
+                )
+                msg.yesButton.setText(gt('覆盖安装'))
+                msg.cancelButton.setText(gt('跳过'))
+                if msg.exec():
+                    overwrite_paths.extend([fp for fp, _ in normal_overwrite])
+
+            # 处理降级覆盖（单独警告）
+            if downgrade_overwrite:
+                warnings = [
+                    f'{name}: {new_v or "未知"} ← {old_v or "未知"}'
+                    for _, name, new_v, old_v in downgrade_overwrite
+                ]
+                msg = MessageBox(
+                    title=gt('⚠️ 版本降级警告'),
+                    content=gt(f'以下插件将降级安装，确定继续？\n\n{chr(10).join(warnings)}'),
+                    parent=self
+                )
+                msg.yesButton.setText(gt('确认降级'))
+                msg.cancelButton.setText(gt('取消'))
+                if msg.exec():
+                    overwrite_paths.extend([fp for fp, _, _, _ in downgrade_overwrite])
+
+            # 执行覆盖安装
+            if overwrite_paths:
+                overwrite_results = self.plugin_import_service.import_plugins(
+                    overwrite_paths, overwrite=True
+                )
+                # 更新结果
+                for i, fp in enumerate(overwrite_paths):
+                    idx = file_paths.index(fp)
+                    results[idx] = overwrite_results[i]
+
+        # 统计结果
+        success_count = sum(1 for r in results if r.success)
+        fail_count = len(results) - success_count
+
+        # 显示结果
+        if success_count > 0:
+            # 刷新应用注册
+            self.ctx.refresh_application_registration()
+            self._refresh_plugin_list()
+
+            InfoBar.success(
+                title=gt('导入成功'),
+                content=gt(f'成功导入 {success_count} 个插件'),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
+
+        if fail_count > 0:
+            fail_messages = [f"{r.plugin_name}: {r.message}" for r in results if not r.success]
+            InfoBar.warning(
+                title=gt('部分导入失败'),
+                content='\n'.join(fail_messages),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=5000,
+                parent=self
+            )
+
+    def _on_import_dir_clicked(self) -> None:
+        """导入目录按钮点击"""
+        dir_path = QFileDialog.getExistingDirectory(
+            self,
+            gt('选择插件目录'),
+            ''
+        )
+
+        if not dir_path:
+            return
+
+        # 预览插件信息
+        preview = self.plugin_import_service.preview_directory(dir_path)
+
+        if not preview:
+            InfoBar.error(
+                title=gt('无效的插件目录'),
+                content=gt('该目录不包含有效的插件结构（缺少 *_factory.py 文件）'),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=5000,
+                parent=self
+            )
+            return
+
+        # 构建预览信息
+        preview_text = f"• {preview.plugin_name}"
+        if preview.version:
+            preview_text += f" (v{preview.version})"
+        if preview.author:
+            preview_text += f" - {preview.author}"
+
+        # 显示预览确认对话框
+        msg = MessageBox(
+            title=gt('确认导入'),
+            content=gt(f'即将导入以下插件：\n\n{preview_text}'),
+            parent=self
+        )
+        msg.yesButton.setText(gt('确认导入'))
+        msg.cancelButton.setText(gt('取消'))
+
+        if not msg.exec():
+            return
+
+        # 尝试导入
+        result = self.plugin_import_service.import_directory(dir_path, overwrite=False)
+
+        if result.success:
+            self.ctx.refresh_application_registration()
+            self._refresh_plugin_list()
+            InfoBar.success(
+                title=gt('导入成功'),
+                content=gt(f'插件 "{result.plugin_name}" 已导入'),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self
+            )
+        elif result.plugin_dir is not None:
+            # 插件已存在，询问是否覆盖
+            # 获取已安装版本
+            installed = next(
+                (p for p in self.ctx.factory_manager.third_party_plugins if p.app_id == result.plugin_name),
+                None
+            )
+            old_ver = installed.version if installed else None
+            new_ver = preview.version
+
+            is_downgrade = self._is_version_lower(new_ver, old_ver)
+
+            if is_downgrade:
+                msg = MessageBox(
+                    title=gt('⚠️ 版本降级警告'),
+                    content=gt(f'插件 "{result.plugin_name}" 将从 {old_ver or "未知"} 降级到 {new_ver or "未知"}，确定继续？'),
+                    parent=self
+                )
+                msg.yesButton.setText(gt('确认降级'))
+            else:
+                msg = MessageBox(
+                    title=gt('插件已存在'),
+                    content=gt(f'插件 "{result.plugin_name}" 已存在，是否覆盖安装？'),
+                    parent=self
+                )
+                msg.yesButton.setText(gt('覆盖安装'))
+
+            msg.cancelButton.setText(gt('取消'))
+
+            if msg.exec():
+                overwrite_result = self.plugin_import_service.import_directory(dir_path, overwrite=True)
+                if overwrite_result.success:
+                    self.ctx.refresh_application_registration()
+                    self._refresh_plugin_list()
+                    InfoBar.success(
+                        title=gt('导入成功'),
+                        content=gt(f'插件 "{overwrite_result.plugin_name}" 已覆盖安装'),
+                        orient=Qt.Horizontal,
+                        isClosable=True,
+                        position=InfoBarPosition.TOP,
+                        duration=3000,
+                        parent=self
+                    )
+                else:
+                    InfoBar.error(
+                        title=gt('导入失败'),
+                        content=overwrite_result.message,
+                        orient=Qt.Horizontal,
+                        isClosable=True,
+                        position=InfoBarPosition.TOP,
+                        duration=5000,
+                        parent=self
+                    )
+        else:
+            InfoBar.error(
+                title=gt('导入失败'),
+                content=result.message,
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=5000,
+                parent=self
+            )
+
+    def _on_refresh_clicked(self) -> None:
+        """刷新按钮点击"""
+        try:
+            self.ctx.refresh_application_registration()
+            self._refresh_plugin_list()
+            InfoBar.success(
+                title=gt('刷新成功'),
+                content=gt('已重新加载所有插件'),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=2000,
+                parent=self
+            )
+        except Exception as e:
+            log.error(f'刷新插件失败: {e}', exc_info=True)
+            InfoBar.error(
+                title=gt('刷新失败'),
+                content=str(e),
+                orient=Qt.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=5000,
+                parent=self
+            )
+
+    def _on_open_dir_clicked(self) -> None:
+        """打开插件目录"""
+
+        plugins_dir = self.plugin_import_service.plugins_dir
+        plugins_dir.mkdir(parents=True, exist_ok=True)
+
+        if sys.platform == 'win32':
+            os.startfile(plugins_dir)
+        elif sys.platform == 'darwin':
+            subprocess.run(['open', plugins_dir])
+        else:
+            subprocess.run(['xdg-open', plugins_dir])
+
+    def _on_delete_plugin(self, plugin_info: PluginInfo) -> None:
+        """删除插件"""
+        # 确认对话框
+        msg_box = MessageBox(
+            gt('确认删除'),
+            gt(f'确定要删除插件 "{plugin_info.app_name}" 吗？此操作不可恢复。'),
+            self
+        )
+        msg_box.yesButton.setText(gt('删除'))
+        msg_box.cancelButton.setText(gt('取消'))
+
+        if not msg_box.exec():
+            return
+
+        # 执行删除
+        if plugin_info.plugin_dir:
+            result = self.plugin_import_service.delete_plugin(plugin_info.plugin_dir)
+            if result.success:
+                # 刷新应用注册
+                self.ctx.refresh_application_registration()
+                self._refresh_plugin_list()
+                InfoBar.success(
+                    title=gt('删除成功'),
+                    content=gt(f'插件 "{plugin_info.app_name}" 已删除'),
+                    orient=Qt.Horizontal,
+                    isClosable=True,
+                    position=InfoBarPosition.TOP,
+                    duration=3000,
+                    parent=self
+                )
+            else:
+                InfoBar.error(
+                    title=gt('删除失败'),
+                    content=result.message,
+                    orient=Qt.Horizontal,
+                    isClosable=True,
+                    position=InfoBarPosition.TOP,
+                    duration=5000,
+                    parent=self
+                )
+
+    def _on_open_homepage(self, plugin_info: PluginInfo) -> None:
+        """打开插件主页"""
+        if plugin_info.homepage:
+            webbrowser.open(plugin_info.homepage)
+
+    def _is_version_lower(self, new_ver: str | None, old_ver: str | None) -> bool:
+        """检查新版本是否低于旧版本
+
+        Args:
+            new_ver: 新版本号
+            old_ver: 旧版本号
+
+        Returns:
+            bool: 如果新版本低于旧版本返回 True
+        """
+        if not new_ver or not old_ver:
+            return False  # 无法比较时不认为是降级
+
+        try:
+            from packaging.version import Version
+            return Version(new_ver) < Version(old_ver)
+        except Exception:
+            # 简单字符串比较作为后备
+            return new_ver < old_ver

--- a/src/zzz_od/gui/view/setting/setting_plugin_interface.py
+++ b/src/zzz_od/gui/view/setting/setting_plugin_interface.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import webbrowser
+from collections.abc import Callable
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QFileDialog, QWidget
@@ -38,10 +39,10 @@ class PluginCard(MultiPushSettingCard):
     def __init__(
         self,
         plugin_info: PluginInfo,
-        on_delete: callable,
-        on_open_homepage: callable,
-        parent=None
-    ):
+        on_delete: Callable[[PluginInfo], None],
+        on_open_homepage: Callable[[PluginInfo], None],
+        parent: QWidget | None = None,
+    ) -> None:
         self.plugin_info = plugin_info
         self.on_delete_callback = on_delete
         self.on_open_homepage_callback = on_open_homepage
@@ -49,11 +50,11 @@ class PluginCard(MultiPushSettingCard):
         # 创建按钮
         buttons = []
 
-        # 主页按钮（如果有链接）
-        if plugin_info.homepage:
-            self.homepage_btn = PushButton(text=gt("主页"))
-            self.homepage_btn.clicked.connect(self._on_homepage_clicked)
-            buttons.append(self.homepage_btn)
+        # 主页按钮（始终创建，通过可见性控制显示）
+        self.homepage_btn = PushButton(text=gt("主页"))
+        self.homepage_btn.clicked.connect(self._on_homepage_clicked)
+        self.homepage_btn.setVisible(bool(plugin_info.homepage))
+        buttons.append(self.homepage_btn)
 
         # 删除按钮
         self.delete_btn = ToolButton(FluentIcon.DELETE, parent=None)
@@ -111,14 +112,13 @@ class PluginCard(MultiPushSettingCard):
         self.contentLabel.setText(content)
 
         # 更新主页按钮可见性
-        if hasattr(self, 'homepage_btn'):
-            self.homepage_btn.setVisible(bool(plugin_info.homepage))
+        self.homepage_btn.setVisible(bool(plugin_info.homepage))
 
 
 class SettingPluginInterface(VerticalScrollInterface):
     """插件管理界面"""
 
-    def __init__(self, ctx: ZContext, parent=None):
+    def __init__(self, ctx: ZContext, parent: QWidget | None = None) -> None:
         self.ctx: ZContext = ctx
         self.plugin_import_service = PluginImportService(ctx)
         self._plugin_cards: list[PluginCard] = []
@@ -319,9 +319,11 @@ class SettingPluginInterface(VerticalScrollInterface):
 
         # 如果有已存在的插件，询问是否覆盖
         if existing_plugins:
-            # 获取已安装插件的版本信息
+            # 获取已安装插件的版本信息（以 plugin_dir.name 为键，与 ImportResult.plugin_name 匹配）
             installed_plugins = {
-                p.app_id: p for p in self.ctx.factory_manager.third_party_plugins
+                p.plugin_dir.name: p
+                for p in self.ctx.factory_manager.third_party_plugins
+                if p.plugin_dir is not None
             }
 
             # 检查版本信息
@@ -329,7 +331,7 @@ class SettingPluginInterface(VerticalScrollInterface):
             for fp, r in existing_plugins:
                 preview = self.plugin_import_service.preview_plugin(fp)
                 new_ver = preview.version if preview else None
-                old_ver = installed_plugins.get(r.plugin_name, None)
+                old_ver = installed_plugins.get(r.plugin_name)
                 old_ver_str = old_ver.version if old_ver else None
 
                 is_downgrade = self._is_version_lower(new_ver, old_ver_str)
@@ -474,9 +476,13 @@ class SettingPluginInterface(VerticalScrollInterface):
             )
         elif result.plugin_dir is not None:
             # 插件已存在，询问是否覆盖
-            # 获取已安装版本
+            # 获取已安装版本（以 plugin_dir.name 与 ImportResult.plugin_name 匹配）
             installed = next(
-                (p for p in self.ctx.factory_manager.third_party_plugins if p.app_id == result.plugin_name),
+                (
+                    p
+                    for p in self.ctx.factory_manager.third_party_plugins
+                    if p.plugin_dir is not None and p.plugin_dir.name == result.plugin_name
+                ),
                 None
             )
             old_ver = installed.version if installed else None


### PR DESCRIPTION
- 修复 ZIP 路径穿越漏洞：净化 _get_plugin_dir_name 返回的目录名， 拒绝 ../ 和绝对路径；对每个 ZIP 条目逐文件安全提取并做路径验证
- 修复 delete_plugin 安全检查绕过：先 resolve 路径再验证， 禁止删除 plugins 根目录
- 覆盖安装改为原子操作：先解压/复制到临时目录，验证后替换旧目录， 避免 I/O 异常导致旧版本数据丢失
- 修复 PluginCard 复用卡牌时主页按钮可能不出现的问题： 始终创建按钮，仅控制可见性
- 修复 installed_plugins 查询以 plugin_dir.name 为键， 解决 app_id 与目录名不一致导致降级/覆盖判断被绕过的问题
- 补充类型标注：callable → Callable，__init__ 添加返回类型